### PR TITLE
Fix typo of the input file name variable.

### DIFF
--- a/_episodes/03-analysis.md
+++ b/_episodes/03-analysis.md
@@ -47,7 +47,7 @@ We will need momentum, generator status, and particle species information for th
 > ```c++
 > // Set up input file chain
 > TChain *mychain = new TChain("events");
-> mychain->Add(input_file_name);
+> mychain->Add(infile);
 >
 > // Initialize reader
 > TTreeReader tree_reader(mychain);


### PR DESCRIPTION
Fixed typo of variable name for the input file name. Previously had `input_file_name` and `infile`, now there's just `infile`.
